### PR TITLE
Test and add support for OpenAPI 3.1 new specs

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -502,6 +502,34 @@ func TestGenerateFromSimpleOpenAPIWithOpenIdConnectWithGlobalAndLocalOverrideSec
 	assert.Equal(t, expectedRule, got)
 }
 
+func TestGenerateFromPetstoreOpenAPI(t *testing.T) {
+	teardownSuite := setupSuite(t)
+	defer teardownSuite(t)
+
+	g, newGeneratorErr := newGenerator("../test/stub/petstore.openapi.json", &config.Config{})
+	if newGeneratorErr != nil {
+		t.Fatal(newGeneratorErr)
+	}
+
+	_, err := g.Generate()
+
+	require.NoError(t, err)
+}
+
+func TestGenerateFromPetstoreOpenAPI31(t *testing.T) {
+	teardownSuite := setupSuite(t)
+	defer teardownSuite(t)
+
+	g, newGeneratorErr := newGenerator("../test/stub/petstore31.openapi.json", &config.Config{})
+	if newGeneratorErr != nil {
+		t.Fatal(newGeneratorErr)
+	}
+
+	_, err := g.Generate()
+
+	require.NoError(t, err)
+}
+
 func TestGenerateFromPetstoreWithOpenIdConnect(t *testing.T) {
 	teardownSuite := setupSuite(t)
 	defer teardownSuite(t)

--- a/test/stub/petstore31.openapi.json
+++ b/test/stub/petstore31.openapi.json
@@ -1,0 +1,428 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.1",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.1 specification.\nYou can find out more about\nSwagger at [https://swagger.io](https://swagger.io).",
+    "termsOfService": "https://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.9",
+    "summary": "Pet Store 3.1",
+    "x-namespace": "swagger"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "https://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v31"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "https://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet.",
+        "description": "Update an existing pet by Id.",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Pet object that needs to be updated in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "A Pet in JSON Format",
+                "required": [
+                  "id"
+                ],
+                "writeOnly": true
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "A Pet in XML Format",
+                "required": [
+                  "id"
+                ],
+                "writeOnly": true
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in XML Format",
+                  "readOnly": true
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in JSON Format",
+                  "readOnly": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store.",
+        "description": "Add a new pet to the store.",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "A Pet in JSON Format",
+                "required": [
+                  "id"
+                ],
+                "writeOnly": true
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "A Pet in XML Format",
+                "required": [
+                  "id"
+                ],
+                "writeOnly": true
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in XML Format",
+                  "readOnly": true
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in JSON format",
+                  "readOnly": true
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by it's identifier.",
+        "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or non-integers will simulate API error conditions.",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "description": "param ID of pet that needs to be fetched",
+              "exclusiveMaximum": 10,
+              "exclusiveMinimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in JSON format"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet",
+                  "description": "A Pet in XML format"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          },
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Category": {
+        "$id": "/api/v31/components/schemas/category",
+        "description": "Category",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "Pet": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "Pet",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category",
+            "description": "Pet Category"
+          },
+          "name": {
+            "type": "string",
+            "examples": [
+              "doggie"
+            ]
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            },
+            "xml": {
+              "wrapped": true
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            },
+            "xml": {
+              "wrapped": true
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          },
+          "availableInstances": {
+            "type": "integer",
+            "format": "int32",
+            "examples": [
+              "7"
+            ],
+            "exclusiveMaximum": 10,
+            "exclusiveMinimum": 1,
+            "swagger-extension": true
+          },
+          "petDetailsId": {
+            "type": "integer",
+            "format": "int64",
+            "$ref": "/api/v31/components/schemas/petdetails#pet_details_id"
+          },
+          "petDetails": {
+            "$ref": "/api/v31/components/schemas/petdetails"
+          }
+        },
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "xml": {
+          "name": "Pet"
+        }
+      },
+      "PetDetails": {
+        "$id": "/api/v31/components/schemas/petdetails",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": "https://spec.openapis.org/oas/3.1/schema-base",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "$anchor": "pet_details_id",
+            "examples": [
+              "10"
+            ]
+          },
+          "category": {
+            "$ref": "/api/v31/components/schemas/category",
+            "description": "PetDetails Category"
+          },
+          "tag": {
+            "$ref": "/api/v31/components/schemas/tag"
+          }
+        },
+        "xml": {
+          "name": "PetDetails"
+        }
+      },
+      "Tag": {
+        "$id": "/api/v31/components/schemas/tag",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore31.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "mutual_tls": {
+        "type": "mutualTLS"
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  },
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "requestBody": {
+          "description": "Information about a new pet in the system",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet",
+                "description": "Webhook Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Test support for OpenAPI 3.1 new specs (#94).

Unfortunately, this project is not compatible with OpenAPI 3.1 yet. More information about in this comment: https://github.com/cerberauth/openapi-oathkeeper/issues/94#issuecomment-2780884581